### PR TITLE
Bump to 0.74.0 and other updates to Role

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
@@ -44,7 +44,7 @@ jobs:
   build:
 
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 8
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,21 @@ eksctl_version: 0.74.0
 eksctl_osarch: amd64
 eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
 eksctl_bin_path: /usr/local/bin
+eksctl_file_owner: root
+eksctl_file_group: root
 ```
 
 ### Variables table:
 
-Variable        | Description
---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
-eksctl_app      | Defines the app to install i.e. **eksctl**
-eksctl_version  | Defined to dynamically fetch the desired version to install. Defaults to: **0.74.0**
-eksctl_osarch   | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture.
-eksctl_dl_url   | Defines URL to download the eksctl binary from.
-eksctl_bin_path | Defined to dynamically set the appropriate path to store eksctl binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+Variable          | Description
+----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
+eksctl_app        | Defines the app to install i.e. **eksctl**
+eksctl_version    | Defined to dynamically fetch the desired version to install. Defaults to: **0.74.0**
+eksctl_osarch     | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture.
+eksctl_dl_url     | Defines URL to download the eksctl binary from.
+eksctl_bin_path   | Defined to dynamically set the appropriate path to store eksctl binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+eksctl_file_owner | Owner for the binary file of eksctl.
+eksctl_file_group | Group for the binary file of eksctl.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 eksctl_app: eksctl
-eksctl_version: 0.73.0
+eksctl_version: 0.74.0
 eksctl_osarch: amd64
 eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
 eksctl_bin_path: /usr/local/bin
@@ -27,7 +27,7 @@ eksctl_bin_path: /usr/local/bin
 Variable        | Description
 --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
 eksctl_app      | Defines the app to install i.e. **eksctl**
-eksctl_version  | Defined to dynamically fetch the desired version to install. Defaults to: **0.73.0**
+eksctl_version  | Defined to dynamically fetch the desired version to install. Defaults to: **0.74.0**
 eksctl_osarch   | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture.
 eksctl_dl_url   | Defines URL to download the eksctl binary from.
 eksctl_bin_path | Defined to dynamically set the appropriate path to store eksctl binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for eksctl
 
 eksctl_app: eksctl
-eksctl_version: 0.73.0
+eksctl_version: 0.74.0
 eksctl_osarch: amd64
 eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
 eksctl_bin_path: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ eksctl_version: 0.74.0
 eksctl_osarch: amd64
 eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
 eksctl_bin_path: /usr/local/bin
+eksctl_file_owner: root
+eksctl_file_group: root

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint: |
     flake8
 platforms:
   - name: ${DISTRO:-ubuntu-18.04}
-    image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     pre_build_image: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=ansible-role-eksctl
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-eksctl
 sonar.coverage.exclusions=**/**
-sonar.python=3
+sonar.python.version=3
 #sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -8,3 +8,5 @@
     extra_opts:
       - eksctl
     remote_src: yes
+    owner: "{{ eksctl_file_owner }}"
+    group: "{{ eksctl_file_group }}"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -8,3 +8,5 @@
     extra_opts:
       - eksctl
     remote_src: yes
+    owner: "{{ eksctl_file_owner }}"
+    group: "{{ eksctl_file_group }}"


### PR DESCRIPTION
- Bump `eksctl` to 0.74.0
- additional variables for eksctl file owner/group
- Debian/Ubuntu/EL family tasks updated with variables for eksctl file owner/group
- Bump default image in molecule config to Ubuntu 20.04
- Bump default github action runner to Ubuntu 20.04 for `build-and-test` & `release` workflow