### PR TITLE
Bump eksctl to 0.80.0 & variables isolation for os arch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -17,24 +17,28 @@ Available variables are listed below (located in `defaults/main.yml`):
 ```yaml
 eksctl_app: eksctl
 eksctl_version: 0.80.0
-eksctl_osarch: amd64
-eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
+eksctl_os: Linux
+eksctl_arch: amd64
+eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_{{ eksctl_os }}_{{ eksctl_arch }}.tar.gz
 eksctl_bin_path: /usr/local/bin
 eksctl_file_owner: root
 eksctl_file_group: root
+eksctl_file_permission_mode: '0755'
 ```
 
 ### Variables table:
 
-Variable          | Description
------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------
-eksctl_app        | Defines the app to install i.e. **eksctl**
-eksctl_version    | Defined to dynamically fetch the desired version to install. Defaults to: **0.80.0**
-eksctl_osarch     | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture.
-eksctl_dl_url     | Defines URL to download the eksctl binary from.
-eksctl_bin_path   | Defined to dynamically set the appropriate path to store eksctl binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
-eksctl_file_owner | Owner for the binary file of eksctl.
-eksctl_file_group | Group for the binary file of eksctl.
+Variable                    | Description
+--------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
+eksctl_app                  | Defines the app to install i.e. **eksctl**
+eksctl_version              | Defined to dynamically fetch the desired version to install. Defaults to: **0.80.0**
+eksctl_os                   | Defines os type. Defaults to: **Linux**
+eksctl_arch                 | Defines os architecture. Defaults to: **amd64**
+eksctl_dl_url               | Defines URL to download the eksctl binary from.
+eksctl_bin_path             | Defined to dynamically set the appropriate path to store eksctl binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+eksctl_file_owner           | Owner for the binary file of eksctl.
+eksctl_file_group           | Group for the binary file of eksctl.
+eksctl_file_permission_mode | Defines the permission mode level for the file. Defaults to: `0755`
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 eksctl_app: eksctl
-eksctl_version: 0.79.0
+eksctl_version: 0.80.0
 eksctl_osarch: amd64
 eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
 eksctl_bin_path: /usr/local/bin
@@ -29,7 +29,7 @@ eksctl_file_group: root
 Variable          | Description
 ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
 eksctl_app        | Defines the app to install i.e. **eksctl**
-eksctl_version    | Defined to dynamically fetch the desired version to install. Defaults to: **0.79.0**
+eksctl_version    | Defined to dynamically fetch the desired version to install. Defaults to: **0.80.0**
 eksctl_osarch     | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture.
 eksctl_dl_url     | Defines URL to download the eksctl binary from.
 eksctl_bin_path   | Defined to dynamically set the appropriate path to store eksctl binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for eksctl
 
 eksctl_app: eksctl
-eksctl_version: 0.79.0
+eksctl_version: 0.80.0
 eksctl_osarch: amd64
 eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
 eksctl_bin_path: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,10 @@
 
 eksctl_app: eksctl
 eksctl_version: 0.80.0
-eksctl_osarch: amd64
-eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_Linux_{{ eksctl_osarch }}.tar.gz
+eksctl_os: Linux
+eksctl_arch: amd64
+eksctl_dl_url: https://github.com/weaveworks/{{ eksctl_app }}/releases/download/v{{ eksctl_version }}/{{ eksctl_app }}_{{ eksctl_os }}_{{ eksctl_arch }}.tar.gz
 eksctl_bin_path: /usr/local/bin
 eksctl_file_owner: root
 eksctl_file_group: root
+eksctl_file_permission_mode: '0755'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: ${DISTRO:-ubuntu-18.04}
+  - name: ${DISTRO:-ubuntu-20.04}
     image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -10,3 +10,4 @@
     remote_src: yes
     owner: "{{ eksctl_file_owner }}"
     group: "{{ eksctl_file_group }}"
+    mode: "{{ eksctl_file_permission_mode }}"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -10,3 +10,4 @@
     remote_src: yes
     owner: "{{ eksctl_file_owner }}"
     group: "{{ eksctl_file_group }}"
+    mode: "{{ eksctl_file_permission_mode }}"


### PR DESCRIPTION
- Separate out variables for OS and Arch
- Set owner and group for `eksctl` file.
- Set mode for the `eksctl` file.
- Bump `eksctl` to 0.80.0